### PR TITLE
previous annotations show in GUI

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -8,6 +8,19 @@
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
+FUNCTIONAL_GROUPS = ["aromatics",
+                    "alcohols",
+                    "amines",
+                    "esters",
+                    "alkene",
+                    "carb",
+                    "ketones",
+                    "phenol",
+                    "nitriles",
+                    "amides",
+                    "aldehydes",
+                    "alkyne"]
+
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
@@ -150,6 +163,7 @@ class Ui_MainWindow(object):
         self.label_2.setText(_translate("MainWindow", "TextLabel"))
         self.pushButton_2.setText(_translate("MainWindow", "Go"))
 
+    
 
 
 # --- Add MainWindow subclass for scaling ---


### PR DESCRIPTION
After communication with Qichen, it was suggested to enable a functionality in the application that allows the user to visualize previously annotated functional groups. This PR addresses those changes. It allows the user to see annotations and a new helper method within main.py -> App takes care of drawing the new boxes